### PR TITLE
Next releae

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ var list = List.Cons(1, List.Cons(2, List.Cons(3, List.Nil())));
 console.log(toString(list)); // => '1 : 2 : 3 : Nil'
 ```
 
+### Disabling type checking
+
+Type checking can be disabled, for instance in production, by setting
+`Type.check` to `false`.
+
 ## Author & license
 
 union-type was made by [paldepind](https://twitter.com/paldepind) and is

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Thus the above example is equivalent to this:
 var Point = Type({Point: [Number, Number]});
 ```
 
+### Records
+
 Instead of supplying only the types of the individual constructors it is also
 possible to define records using object descriptions:
 
@@ -51,19 +53,20 @@ possible to define records using object descriptions:
 var Point = Type({Point: {x: Number, y: Number}});
 ```
 
+### Instance methods
+
 Furthermore it is possible to add instance methods. A Maybe type with a map
 function could thus be defined as follows:
 
 ```javascript
 var T = function () { return true; };
-var maybeMap(fn) {
-    var that = this;
-    return this.case({
-        Nothing: this.Nothing,
-        Just: function(v) { return that.Just(fn(v)); }
-    }, this);
+var Maybe = Type({Just: [T], Nothing: []});
+Maybe.prototype.map = function(fn) {
+  return Maybe.case({
+    Nothing: () => Maybe.Nothing(),
+    Just: (v) => Maybe.Just(fn(v))
+  }, this);
 };
-var Maybe = Type({Just: [T], Nothing: []}, {map: maybeMap});
 var just = Maybe.Just(1);
 var nothing = Maybe.Nothing();
 nothing.map(add(1)); // => Nothing

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ associated with the possible values.
 ### Defining a union type
 
 union-type exports a single function `Type`. Union types are created by
-passing the `Type` function a definition object.
+passing the `Type` function a definition object. The easiest way to define
+a Type is as follows:
 
 ```javascript
 function isNumber(n) { return typeof n === 'number'; }
@@ -41,6 +42,32 @@ Thus the above example is equivalent to this:
 
 ```javascript
 var Point = Type({Point: [Number, Number]});
+```
+
+Instead of supplying only the types of the individual constructors it is also
+possible to define records using object descriptions:
+
+```javascript
+var Point = Type({Point: {x: Number, y: Number}});
+```
+
+Furthermore it is possible to add instance methods. A Maybe type with a map
+function could thus be defined as follows:
+
+```javascript
+var T = function () { return true; };
+var maybeMap(fn) {
+    var that = this;
+    return this.case({
+        Nothing: this.Nothing,
+        Just: function(v) { return that.Just(fn(v)); }
+    }, this);
+};
+var Maybe = Type({Just: [T], Nothing: []}, {map: maybeMap});
+var just = Maybe.Just(1);
+var nothing = Maybe.Nothing();
+nothing.map(add(1)); // => Nothing
+just.map(add(1)); // => Just(2)
 ```
 
 Finally fields can be described in terms of other types.
@@ -85,6 +112,19 @@ helpful error is thrown.
 ```javascript
 var p = Point.Point('bad', 4);
 // throws TypeError: wrong value bad passed to location 0 in Point
+```
+
+As mentioned earlier you can also define records using object descriptions:
+
+```javascript
+var Point = Type({Point: {x: Number, y: Number}});
+```
+
+Types defined using the record syntax have to be constructed using the respective
+`<name>Of` constructor. The Point type above is hence constructed using `PointOf`:
+
+```javascript
+var p = Point.PointOf({x: 1, y: 1});
 ```
 
 ### Switching on union types
@@ -178,8 +218,19 @@ const advancePlayerOnlyUp = (action, player) =>
 
 ### Extracting fields from a union type
 
-The value of a union type is an array. This makes it easy to access the
-different fields.
+If your type was defined using the record syntax you can access the fields
+through the name you specified:
+
+```javascript
+var Person = Type({Person: {name: String, age: Number, shape: Shape}});
+var person = Person.PersonOf({name: 'Simon', age: 21, shape: Circle});
+var name = person.name;
+var age = person.age;
+var favoriteShape = person.shape;
+```
+
+If your type was not created using the record syntax the fields have to
+be extracted by indexing your union type:
 
 ```javascript
 var Person = Type({Person: [String, Number, Shape]});

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Types defined using the record syntax have to be constructed using the respectiv
 var p = Point.PointOf({x: 1, y: 1});
 ```
 
+Alternatively records can be constructed in the same way as regular types.
+
+```javascript
+var p = Point.Point(1, 1);
+```
+
 ### Switching on union types
 
 Every created type has a `case` function available along with its value

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "release-major": "xyz --repo git@github.com:paldepind/union-type.git --increment major",
     "release-minor": "xyz --repo git@github.com:paldepind/union-type.git --increment minor",
     "release-patch": "xyz --repo git@github.com:paldepind/union-type.git --increment patch",
-    "test": "mocha --compilers js:babel/register",
+    "test": "mocha --compilers js:babel/register"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "ramda": "^0.19.1"
   },
   "devDependencies": {
+    "babel": "^5.8.21",
     "browserify": "^10.2.4",
     "mocha": "^2.3.4",
     "xyz": "0.5.x"
@@ -19,7 +20,7 @@
     "release-major": "xyz --repo git@github.com:paldepind/union-type.git --increment major",
     "release-minor": "xyz --repo git@github.com:paldepind/union-type.git --increment minor",
     "release-patch": "xyz --repo git@github.com:paldepind/union-type.git --increment patch",
-    "test": "mocha"
+    "test": "mocha --compilers js:babel/register",
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -121,7 +121,7 @@ describe('union type', function() {
       var AnotherAction = Type({Translate: [Number]});
       assert.throws(function() {
         sum(AnotherAction.Translate(12));
-      }, /wrong type/);
+      }, /Non-exhaustive patterns/);
     });
     it('calls back to placeholder', function() {
       var called = false;

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,9 @@ var Type = require('../union-type.js');
 
 function isNumber(n) { return typeof n === 'number'; }
 function T() { return true; }
+function add(n) {
+  return function(m) { return n + m; }
+}
 
 describe('union type', function() {
   it('returns type with constructors', function() {
@@ -82,6 +85,24 @@ describe('union type', function() {
       assert.equal(p[0], 1);
       assert.equal(p.y, 2);
       assert.equal(p[1], 2);
+    });
+  });
+  describe('type methods', function() {
+    it('can add instance methods', function() {
+      function maybeMap(fn) {
+        var that = this;
+        return this.case({
+          Nothing: this.Nothing,
+          Just: function(v) { return that.Just(fn(v)); },
+        }, this);
+      }
+      var Maybe = Type({Just: [T], Nothing: []}, {map: maybeMap});
+      var just1 = Maybe.Just(1);
+      var just4 = just1.map(add(3));
+      assert.equal(just4[0], 4);
+      var nothing = Maybe.Nothing();
+      var alsoNothing = nothing.map(add(3));
+      assert.equal(alsoNothing.name, 'Nothing');
     });
   });
   describe('case', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,6 @@ var assert = require('assert');
 var Type = require('../union-type.js');
 
 function isNumber(n) { return typeof n === 'number'; }
-
 function T() { return true; }
 
 describe('union type', function() {
@@ -109,18 +108,20 @@ describe('union type', function() {
     });
   });
   describe('caseOn', function() {
-    var Modification = Type({Append: [Number], Remove: [Number], Sort: []});
+    var Modification = Type({Append: [Number], Remove: [Number], Slice: [Number, Number], Sort: []});
     var update = Modification.caseOn({
       Append: function(number, list) { return list.concat([number]); },
       Remove: function(number, list) {
         var idx = list.indexOf(number);
         return list.slice(0, idx).concat(list.slice(idx+1));
       },
+      Slice: function(begin, end, list) { return list.slice(begin, end); },
       Sort: function(list) { return list.sort(); },
     });
     it('passes argument along to case functions', function() {
       assert.deepEqual(update(Modification.Append(3), [1, 2]), [1, 2, 3]);
       assert.deepEqual(update(Modification.Remove(2), [1, 2, 3, 4]), [1, 3, 4]);
+      assert.deepEqual(update(Modification.Slice(1, 4), [1, 2, 3, 4, 5]), [2, 3, 4]);
       assert.deepEqual(update(Modification.Sort(), [1, 3, 2]), [1, 2, 3]);
     });
     it('partially applied to same action does not affect each other', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -82,17 +82,19 @@ describe('union type', function() {
       var Point = Type({Point: {x: Number, y: Number}});
       var p = Point.PointOf({x: 1, y: 2});
       assert.equal(p.x, 1);
-      assert.equal(p[0], 1);
       assert.equal(p.y, 2);
-      assert.equal(p[1], 2);
     });
     it('can create values from arguments', function() {
       var Point = Type({Point: {x: Number, y: Number}});
       var p = Point.Point(1, 2);
       assert.equal(p.x, 1);
-      assert.equal(p[0], 1);
       assert.equal(p.y, 2);
-      assert.equal(p[1], 2);      
+    });
+    it('does not add numerical properties to records', function() {
+      var Point = Type({Point: {x: Number, y: Number}});
+      var p = Point.Point(1, 2);
+      assert.equal(p[0], undefined);
+      assert.equal(p[1], undefined);
     });
   });
   describe('type methods', function() {
@@ -125,6 +127,7 @@ describe('union type', function() {
       },
       Rotate: function(n) { return n; },
       Scale: function(x, y) {
+	console.log(x, y);
 	return x + y;
       }
     });
@@ -162,7 +165,9 @@ describe('union type', function() {
   describe('caseOn', function() {
     var Modification = Type({Append: [Number], Remove: [Number], Slice: [Number, Number], Sort: []});
     var update = Modification.caseOn({
-      Append: function(number, list) { return list.concat([number]); },
+      Append: function(number, list) {
+	return list.concat([number]);
+      },
       Remove: function(number, list) {
         var idx = list.indexOf(number);
         return list.slice(0, idx).concat(list.slice(idx+1));

--- a/test/index.js
+++ b/test/index.js
@@ -99,14 +99,13 @@ describe('union type', function() {
   });
   describe('type methods', function() {
     it('can add instance methods', function() {
-      function maybeMap(fn) {
-        var that = this;
-        return this.case({
-          Nothing: this.Nothing,
-          Just: function(v) { return that.Just(fn(v)); }
+      var Maybe = Type({Just: [T], Nothing: []});
+      Maybe.prototype.map = function(fn) {
+        return Maybe.case({
+          Nothing: () => Maybe.Nothing(),
+          Just: (v) => Maybe.Just(fn(v))
         }, this);
-      }
-      var Maybe = Type({Just: [T], Nothing: []}, {map: maybeMap});
+      };
       var just1 = Maybe.Just(1);
       var just4 = just1.map(add(3));
       assert.equal(just4[0], 4);

--- a/test/index.js
+++ b/test/index.js
@@ -134,11 +134,11 @@ describe('union type', function() {
     it('throws if no case handler found', function() {
       var called = false;
       var fn = Action.case({
-        Translate: function() { throw new Error(); },
+        Translate: function() { throw new Error(); }
       });
       assert.throws(function() {
         fn(Action.Rotate(30));
-      }, /unhandled/);
+      }, /exhaustive/);
     });
   });
   describe('caseOn', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -86,6 +86,14 @@ describe('union type', function() {
       assert.equal(p.y, 2);
       assert.equal(p[1], 2);
     });
+    it('can create values from arguments', function() {
+      var Point = Type({Point: {x: Number, y: Number}});
+      var p = Point.Point(1, 2);
+      assert.equal(p.x, 1);
+      assert.equal(p[0], 1);
+      assert.equal(p.y, 2);
+      assert.equal(p[1], 2);      
+    });
   });
   describe('type methods', function() {
     it('can add instance methods', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -71,6 +71,19 @@ describe('union type', function() {
       Shape.Rectangle(1, Length.Length(12));
     }, /Rectangle/);
   });
+  describe('records', function() {
+    it('can create types from object descriptions', function() {
+      var Point = Type({Point: {x: Number, y: Number}});
+    });
+    it('can create values from objects', function() {
+      var Point = Type({Point: {x: Number, y: Number}});
+      var p = Point.PointOf({x: 1, y: 2});
+      assert.equal(p.x, 1);
+      assert.equal(p[0], 1);
+      assert.equal(p.y, 2);
+      assert.equal(p[1], 2);
+    });
+  });
   describe('case', function() {
     var Action = Type({Translate: [isNumber, isNumber], Rotate: [isNumber]});
     var sum = Action.case({

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ var Type = require('../union-type.js');
 function isNumber(n) { return typeof n === 'number'; }
 function T() { return true; }
 function add(n) {
-  return function(m) { return n + m; }
+  return function(m) { return n + m; };
 }
 
 describe('union type', function() {
@@ -93,7 +93,7 @@ describe('union type', function() {
         var that = this;
         return this.case({
           Nothing: this.Nothing,
-          Just: function(v) { return that.Just(fn(v)); },
+          Just: function(v) { return that.Just(fn(v)); }
         }, this);
       }
       var Maybe = Type({Just: [T], Nothing: []}, {map: maybeMap});
@@ -106,16 +106,26 @@ describe('union type', function() {
     });
   });
   describe('case', function() {
-    var Action = Type({Translate: [isNumber, isNumber], Rotate: [isNumber]});
+    var Action = Type({
+      Translate: [isNumber, isNumber],
+      Rotate: [isNumber],
+      Scale: {x: Number, y: Number}
+    });
     var sum = Action.case({
       Translate: function(x, y) {
         return x + y;
       },
       Rotate: function(n) { return n; },
+      Scale: function(x, y) {
+	return x + y;
+      }
     });
     it('works on types', function() {
       assert.equal(sum(Action.Translate(10, 8)), 18);
       assert.equal(sum(Action.Rotate(30)), 30);
+    });
+    it('destructs record types', function() {
+      assert.equal(sum(Action.ScaleOf({x: 3, y: 4})), 7);
     });
     it('throws on incorrect type', function() {
       var AnotherAction = Type({Translate: [Number]});
@@ -150,7 +160,7 @@ describe('union type', function() {
         return list.slice(0, idx).concat(list.slice(idx+1));
       },
       Slice: function(begin, end, list) { return list.slice(begin, end); },
-      Sort: function(list) { return list.sort(); },
+      Sort: function(list) { return list.sort(); }
     });
     it('passes argument along to case functions', function() {
       assert.deepEqual(update(Modification.Append(3), [1, 2]), [1, 2, 3]);
@@ -166,9 +176,9 @@ describe('union type', function() {
   });
   describe('caseOn _', function() {
     var Action = Type({Jump: [], Move: [Number]});
-    var Context = {x: 1, y: 2}
+    var Context = {x: 1, y: 2};
     var update = Action.caseOn({
-      _: function(context) { return context; },
+      _: function(context) { return context; }
     });
     it('does not extract fields when matching _', function() {
       assert.deepEqual(update(Action.Jump(), Context), Context);

--- a/test/index.js
+++ b/test/index.js
@@ -127,7 +127,6 @@ describe('union type', function() {
       },
       Rotate: function(n) { return n; },
       Scale: function(x, y) {
-	console.log(x, y);
 	return x + y;
       }
     });

--- a/test/index.js
+++ b/test/index.js
@@ -121,7 +121,7 @@ describe('union type', function() {
       var AnotherAction = Type({Translate: [Number]});
       assert.throws(function() {
         sum(AnotherAction.Translate(12));
-      }, /Non-exhaustive patterns/);
+      }, /wrong type/);
     });
     it('calls back to placeholder', function() {
       var called = false;

--- a/test/index.js
+++ b/test/index.js
@@ -191,4 +191,13 @@ describe('union type', function() {
       assert.equal(toString(list), '1 : 2 : 3 : Nil');
     });
   });
+  describe('iterator support', () => {
+    it('is can be destructured like array', () => {
+      var {Point, PointOf} = Type({Point: {x: Number, y: Number, z: Number}});
+      var p1 = PointOf({x: 1, y: 2, z: 3});
+      var p2 = Point(1, 2, 3);
+      var [x, y, z] = p1;
+      assert.deepEqual([x, y, z], [1, 2, 3]);
+    });
+  });
 });

--- a/union-type.js
+++ b/union-type.js
@@ -1,42 +1,40 @@
 var curryN = require('ramda/src/curryN');
 
-if (process.env.NODE_ENV !== 'production') {
-  var isString = function(s) { return typeof s === 'string'; };
-  var isNumber = function(n) { return typeof n === 'number'; };
-  var isBoolean = function(b) { return typeof b === 'boolean'; };
-  var isObject = function(value) {
-    var type = typeof value;
-    return !!value && (type == 'object' || type == 'function');
-  };
-  var isFunction = function(f) { return typeof f === 'function'; };
-  var isArray = Array.isArray || function(a) { return 'length' in a; };
+var isString = function(s) { return typeof s === 'string'; };
+var isNumber = function(n) { return typeof n === 'number'; };
+var isBoolean = function(b) { return typeof b === 'boolean'; };
+var isObject = function(value) {
+  var type = typeof value;
+  return !!value && (type == 'object' || type == 'function');
+};
+var isFunction = function(f) { return typeof f === 'function'; };
+var isArray = Array.isArray || function(a) { return 'length' in a; };
 
-  var mapConstrToFn = function(group, constr) {
-    return constr === String    ? isString
-         : constr === Number    ? isNumber
-         : constr === Boolean   ? isBoolean
-         : constr === Object    ? isObject
-         : constr === Array     ? isArray
-         : constr === Function  ? isFunction
-         : constr === undefined ? group
-                                : constr;
-  };
+var mapConstrToFn = function(group, constr) {
+  return constr === String    ? isString
+       : constr === Number    ? isNumber
+       : constr === Boolean   ? isBoolean
+       : constr === Object    ? isObject
+       : constr === Array     ? isArray
+       : constr === Function  ? isFunction
+       : constr === undefined ? group
+                              : constr;
+};
 
-  var numToStr = ['first', 'second', 'third', 'fourth', 'fifth', 'sixth', 'seventh', 'eighth', 'ninth', 'tenth'];
+var numToStr = ['first', 'second', 'third', 'fourth', 'fifth', 'sixth', 'seventh', 'eighth', 'ninth', 'tenth'];
 
-  var validate = function(group, validators, name, args) {
-    var validator, v, i;
-    for (i = 0; i < args.length; ++i) {
-      v = args[i];
-      validator = mapConstrToFn(group, validators[i]);
-      if (process.env.NODE_ENV !== 'production' &&
-          (validator.prototype === undefined || !validator.prototype.isPrototypeOf(v)) &&
-          (typeof validator !== 'function' || !validator(v))) {
-        throw new TypeError('wrong value ' + v + ' passed to location ' + numToStr[i] + ' in ' + name);
-      }
+var validate = function(group, validators, name, args) {
+  var validator, v, i;
+  for (i = 0; i < args.length; ++i) {
+    v = args[i];
+    validator = mapConstrToFn(group, validators[i]);
+    if (Type.check === true &&
+        (validator.prototype === undefined || !validator.prototype.isPrototypeOf(v)) &&
+        (typeof validator !== 'function' || !validator(v))) {
+      throw new TypeError('wrong value ' + v + ' passed to location ' + numToStr[i] + ' in ' + name);
     }
-  };
-}
+  }
+};
 
 function valueToArray(value) {
   var i, arr = [];
@@ -63,7 +61,7 @@ function constructor(group, name, fields) {
     var val = Object.create(group.prototype), i;
     val.keys = keys;
     val.name = name;
-    if (process.env.NODE_ENV !== 'production') {
+    if (Type.check === true) {
       validate(group, validators, name, arguments);
     }
     for (i = 0; i < arguments.length; ++i) {
@@ -86,7 +84,7 @@ function rawCase(type, cases, value, arg) {
     handler = cases['_'];
     wildcard = true;
   }
-  if (process.env.NODE_ENV !== 'production') {
+  if (Type.check === true) {
     if (!type.prototype.isPrototypeOf(value)) {
       throw new TypeError('wrong type passed to case');
     } else if (handler === undefined) {
@@ -126,5 +124,7 @@ function Type(desc) {
   }
   return obj;
 }
+
+Type.check = true;
 
 module.exports = Type;

--- a/union-type.js
+++ b/union-type.js
@@ -30,7 +30,7 @@ if (process.env.NODE_ENV !== 'production') {
       v = args[i];
       validator = mapConstrToFn(group, validators[i]);
       if (process.env.NODE_ENV !== 'production' &&
-	  (validator.prototype === undefined || !validator.prototype.isPrototypeOf(v)) &&
+          (validator.prototype === undefined || !validator.prototype.isPrototypeOf(v)) &&
           (typeof validator !== 'function' || !validator(v))) {
         throw new TypeError('wrong value ' + v + ' passed to location ' + numToStr[i] + ' in ' + name);
       }
@@ -109,7 +109,7 @@ function createIterator() {
     next: function() {
       var keys = this.val.keys;
       return this.idx === keys.length
-	? {done: true}
+        ? {done: true}
         : {value: this.val[keys[this.idx++]]};
     }
   };

--- a/union-type.js
+++ b/union-type.js
@@ -90,15 +90,15 @@ function rawCase(type, cases, value, arg) {
 var typeCase = curryN(3, rawCase);
 var caseOn = curryN(4, rawCase);
 
-function Type(desc) {
-  var obj = {};
+function Type(desc, methods) {
+  var obj = methods === undefined ? {} : methods;
+  obj.case = typeCase(obj);
+  obj.caseOn = caseOn(obj);
   for (var key in desc) {
     res = Constructor(obj, key, desc[key]);
     obj[key] = res[key];
     obj[key+'Of'] = res[key+'Of'];
   }
-  obj.case = typeCase(obj);
-  obj.caseOn = caseOn(obj);
   return obj;
 }
 

--- a/union-type.js
+++ b/union-type.js
@@ -22,7 +22,7 @@ var mapConstrToFn = function(group, constr) {
 };
 
 function validate(group, validators, name, args) {
-  var validator, v;
+  var validator, v, i;
   for (i = 0; i < args.length; ++i) {
     v = args[i];
     validator = mapConstrToFn(group, validators[i]);
@@ -90,11 +90,22 @@ function rawCase(type, cases, value, arg) {
 var typeCase = curryN(3, rawCase);
 var caseOn = curryN(4, rawCase);
 
+function createIterator() {
+  return {
+    idx: 0,
+    val: this,
+    next: function() {
+      return this.idx === this.val.length ? {done: true} : {value: this.val[this.idx++]};
+    }
+  };
+}
+
 function Type(desc, methods) {
-  var obj = methods === undefined ? {} : methods;
+  var key, res, obj = methods === undefined ? {} : methods;
   obj.case = typeCase(obj);
   obj.caseOn = caseOn(obj);
-  for (var key in desc) {
+  obj[Symbol ? Symbol.iterator : '@@iterator'] = createIterator;
+  for (key in desc) {
     res = Constructor(obj, key, desc[key]);
     obj[key] = res[key];
     obj[key+'Of'] = res[key+'Of'];

--- a/union-type.js
+++ b/union-type.js
@@ -21,30 +21,54 @@ var mapConstrToFn = function(group, constr) {
                               : constr;
 };
 
+function validate(group, validators, name, args) {
+  var validator, v;
+  for (i = 0; i < args.length; ++i) {
+    v = args[i];
+    validator = mapConstrToFn(group, validators[i]);
+    if ((typeof validator === 'function' && validator(v)) || validator.isPrototypeOf(v)) {
+    } else {
+      throw new TypeError('wrong value ' + v + ' passed to location ' + i + ' in ' + name);
+    }
+  }
+}
+
 function valueToArray(value) {
   return Array.prototype.slice.call(value);
 }
 
-function Constructor(group, name, validators) {
-  return curryN(validators.length, function() {
-    var val = Object.create(group), validator, i, v;
+function extractValues(keys, obj) {
+  var arr = [], i;
+  for (i = 0; i < keys.length; ++i) arr[i] = obj[keys[i]];
+  return arr;
+}
+
+function Constructor(group, name, fields) {
+  var constructors = {}, validators, keys, i;
+  if (isArray(fields)) {
+    validators = fields;
+  } else {
+    keys = Object.keys(fields);
+    validators = extractValues(keys, fields);
+  }
+  function construct() {
+    var val = Object.create(group), i;
     val.length = validators.length;
     val.name = name;
-    if (Type.disableChecking === true) {
-      for (i = 0; i < arguments.length; ++i) val[i] = arguments[i];
-    } else {
-      for (i = 0; i < arguments.length; ++i) {
-        v = arguments[i];
-        validator = mapConstrToFn(group, validators[i]);
-        if ((typeof validator === 'function' && validator(v)) || validator.isPrototypeOf(v)) {
-          val[i] = v;
-        } else {
-          throw new TypeError('wrong value ' + v + ' passed to location ' + i + ' in ' + name);
-        }
-      }
+    if (Type.disableChecking !== true) validate(group, validators, name, arguments);
+    for (i = 0; i < arguments.length; ++i) {
+      val[i] = arguments[i];
+      if (keys !== undefined) val[keys[i]] = arguments[i];
     }
     return val;
-  });
+  }
+  constructors[name] = curryN(validators.length, construct);
+  if (keys !== undefined) {
+    constructors[name+'Of'] = function(obj) {
+      return construct.apply(undefined, extractValues(keys, obj));
+    };
+  }
+  return constructors;
 }
 
 function rawCase(type, cases, value, arg) {
@@ -69,7 +93,9 @@ var caseOn = curryN(4, rawCase);
 function Type(desc) {
   var obj = {};
   for (var key in desc) {
-    obj[key] = Constructor(obj, key, desc[key]);
+    res = Constructor(obj, key, desc[key]);
+    obj[key] = res[key];
+    obj[key+'Of'] = res[key+'Of'];
   }
   obj.case = typeCase(obj);
   obj.caseOn = caseOn(obj);

--- a/union-type.js
+++ b/union-type.js
@@ -21,40 +21,43 @@ var mapConstrToFn = function(group, constr) {
                               : constr;
 };
 
+function valueToArray(value) {
+  return Array.prototype.slice.call(value);
+}
+
 function Constructor(group, name, validators) {
   return curryN(validators.length, function() {
-    var val = [], validator, i, v;
+    var val = Object.create(group), validator, i, v;
+    val.length = validators.length;
+    val.name = name;
     if (Type.disableChecking === true) {
       for (i = 0; i < arguments.length; ++i) val[i] = arguments[i];
     } else {
       for (i = 0; i < arguments.length; ++i) {
         v = arguments[i];
         validator = mapConstrToFn(group, validators[i]);
-        if ((typeof validator === 'function' && validator(v)) ||
-            (v !== undefined && v !== null && v.of === validator)) {
+        if ((typeof validator === 'function' && validator(v)) || validator.isPrototypeOf(v)) {
           val[i] = v;
         } else {
           throw new TypeError('wrong value ' + v + ' passed to location ' + i + ' in ' + name);
         }
       }
     }
-    val.of = group;
-    val.name = name;
     return val;
   });
 }
 
-function rawCase(type, cases, action, arg) {
-  if (type !== action.of) throw new TypeError('wrong type passed to case');
-  var name = action.name in cases ? action.name
-           : '_' in cases         ? '_'
-                                  : undefined;
+function rawCase(type, cases, value, arg) {
+  if (!type.isPrototypeOf(value)) throw new TypeError('wrong type passed to case');
+  var name = value.name in cases ? value.name
+           : '_' in cases        ? '_'
+                                 : undefined;
   if (name === undefined) {
     throw new Error('unhandled value passed to case');
   } else {
     var args = name === "_" ? [arg]
-             : arg !== undefined ? action.concat([arg])
-             : action
+             : arg !== undefined ? valueToArray(value).concat([arg])
+             : value;
 
     return cases[name].apply(undefined, args);
   }


### PR DESCRIPTION
Thanks to great ideas from @alexeygolev, help from @gilligan and inspiration from @scott-christopher's work [here](https://github.com/ramda/ramda-fantasy/pull/67) I'm planning to do a new breaking release. I'd really like some feedback and opinions :smile: 

New features include

* Implementation is based on prototypes, should give better performance
* All type checks are disabled in production builds. Type checking code can be completely "compiled away" for browser builds.
* Records are now supported with the following syntax:

```js
var Point = Type({Point: {x: Number, y: Number}});

var Shape = Type({
  Circle: {radius: Integer, center: Point},
  Rectangle: {upperLeft: Point, bottomRight: Point},
});
```

Fields can be accessed like normal properties. Eg. `circle.radius`. Records support destruction and pattern matching like regular union types.

* Instance methods can be created like below. This for instance allow for implementation of ADTs that support fantasy land.

```js
var Maybe = Type({Just: [T], Nothing: []});
Maybe.prototype.map = function(fn) {
  return Maybe.case({
    Nothing: () => Maybe.Nothing(),
    Just: (v) => Maybe.Just(fn(v))
  }, this);
};
var just = Maybe.Just(1);
var nothing = Maybe.Nothing();
nothing.map(add(1)); // => Nothing
just.map(add(1)); // => Just(2)
```

I'm also considering deprecating `switch` and `switchOn` and renaming them to `match` and `matchOn`. If anyone has a better name than `matchOn` I'd love to hear it.