### PR TITLE
Improve type error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ If you in any way pass a field value that does not match the specification a
 helpful error is thrown.
 
 ```javascript
-var p = Point.Point('bad', 4);
-// throws TypeError: wrong value bad passed to location 0 in Point
+var p = Point.Point('foo', 4);
+// throws TypeError: bad value 'foo' passed to first argument of constructor Point
 ```
 
 As mentioned earlier you can also define records using object descriptions:

--- a/test/index.js
+++ b/test/index.js
@@ -44,7 +44,7 @@ describe('union type', function() {
       var Age = Type({Age: [Number]});
       assert.throws(function() {
         Age.Age('12');
-      }, /wrong value/);
+      }, /bad value/);
     });
     it('throws on too many arguments', function() {
       var Foo = Type({Foo: [Number, Number]});
@@ -64,7 +64,7 @@ describe('union type', function() {
       var Exists = Type({Exists: [Boolean]});
       assert.throws(function() {
         Exists.Exists('12');
-      }, /wrong value/);
+      }, /bad value/);
     });
   });
   it('nest types', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -46,6 +46,12 @@ describe('union type', function() {
         Age.Age('12');
       }, /wrong value/);
     });
+    it('throws on too many arguments', function() {
+      var Foo = Type({Foo: [Number, Number]});
+      assert.throws(function() {
+        Foo.Foo(3, 3, 3);
+      }, /too many arguments/);
+    });
     it('accepts boolean true with primitive constructors', function() {
       var Exists = Type({Exists: [Boolean]});
       assert.equal(Exists.Exists(true)[0], true);

--- a/union-type.js
+++ b/union-type.js
@@ -26,7 +26,7 @@ var numToStr = ['first', 'second', 'third', 'fourth', 'fifth', 'sixth', 'seventh
 var validate = function(group, validators, name, args) {
   var validator, v, i;
   if (args.length > validators.length) {
-    throw new TypeError('too many arguments to constructor ' + name
+    throw new TypeError('too many arguments supplied to constructor ' + name
       + ' (expected ' + validators.length + ' but got ' + args.length + ')');
   }
   for (i = 0; i < args.length; ++i) {

--- a/union-type.js
+++ b/union-type.js
@@ -35,7 +35,7 @@ var validate = function(group, validators, name, args) {
         (validator.prototype === undefined || !validator.prototype.isPrototypeOf(v)) &&
         (typeof validator !== 'function' || !validator(v))) {
       var strVal = typeof v === 'string' ? "'" + v + "'" : v; // put the value in quotes if it's a string
-      throw new TypeError('bad value ' + strVal + ' passed to ' + numToStr[i] + ' argument of constructor ' + name);
+      throw new TypeError('bad value ' + strVal + ' passed as ' + numToStr[i] + ' argument to constructor ' + name);
     }
   }
 };

--- a/union-type.js
+++ b/union-type.js
@@ -25,6 +25,9 @@ var numToStr = ['first', 'second', 'third', 'fourth', 'fifth', 'sixth', 'seventh
 
 var validate = function(group, validators, name, args) {
   var validator, v, i;
+  if (args.length > validators.length) {
+    throw new TypeError('too many arguments to constructor ' + name);
+  }
   for (i = 0; i < args.length; ++i) {
     v = args[i];
     validator = mapConstrToFn(group, validators[i]);

--- a/union-type.js
+++ b/union-type.js
@@ -26,7 +26,8 @@ var numToStr = ['first', 'second', 'third', 'fourth', 'fifth', 'sixth', 'seventh
 var validate = function(group, validators, name, args) {
   var validator, v, i;
   if (args.length > validators.length) {
-    throw new TypeError('too many arguments to constructor ' + name);
+    throw new TypeError('too many arguments to constructor ' + name
+      + ' (expected ' + validators.length + ' but got ' + args.length + ')');
   }
   for (i = 0; i < args.length; ++i) {
     v = args[i];

--- a/union-type.js
+++ b/union-type.js
@@ -34,7 +34,8 @@ var validate = function(group, validators, name, args) {
     if (Type.check === true &&
         (validator.prototype === undefined || !validator.prototype.isPrototypeOf(v)) &&
         (typeof validator !== 'function' || !validator(v))) {
-      throw new TypeError('wrong value ' + v + ' passed to location ' + numToStr[i] + ' in ' + name);
+      var strVal = typeof v === 'string' ? "'" + v + "'" : v; // put the value in quotes if it's a string
+      throw new TypeError('bad value ' + strVal + ' passed to ' + numToStr[i] + ' argument of constructor ' + name);
     }
   }
 };


### PR DESCRIPTION
- Tweak the wording of the error message when giving an argument of the wrong type to a constructor... currently if you do something like
  ```javsacript
  var Point = Type({Point: [Number, Number]})
  Point.Point(0, 'foo')
  ```
  
  you'll get this oddly-worded error:
  ```
  wrong value foo passed to location second in Point
  ```
  
  With this change the message becomes
  ```
  bad value 'foo' passed as second argument to constructor Point
  ```
- Give a special error message for too many arguments to a constructor:
  ```javsacript
  Point.Point(0, 1, 2)
  ```
  
  will throw
  ```
  too many arguments to constructor Point (expected 2 but got 3)
  ```