### PR TITLE
Add simplified means of expressing records and newtypes

### DIFF
--- a/union-type.js
+++ b/union-type.js
@@ -127,4 +127,22 @@ function Type(desc) {
 
 Type.check = true;
 
+// Simplified syntax for creating records
+Type.Record = function (desc) {
+  const type = Type({
+    record: desc
+  })
+  type.create = type.recordOf
+  return type
+}
+
+// Newtypes -- types isomorphic to but distinct from another type
+Type.New = function (wrappedType) {
+  const type = Type({
+    newType: { value: wrappedType }
+  })
+  type.create = value => type.newTypeOf({value})
+  return type
+}
+
 module.exports = Type;


### PR DESCRIPTION
`Type.New` lets you make a type which is isomorphic to, but distinct from another type:
```javascript
var ID = Type.New(String)
```

`Type.Record` lets you make a type with a single constructor which you don't have to name:
```javascript
var Person = Type.Record({
  id: ID,
  name: String,
  age: Number
})
```

Use `.create()` to make instances of a `Type.Record` or `Type.New`:
```javascript
var fred = Person.create({
  id: ID.create('2ialp7b4lu'), // passing a simple string here would of course be an error
  name: 'Fred',
  age: 24
})
```

To extract the wrapped value of a newtype, use `.value`:
```javascript
console.log(fred.id.value) // prints '2ialp7b4lu'
```