### PR TITLE
Add case and caseOn as instance methods for types

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,31 @@ const advancePlayerOnlyUp = (action, player) =>
   });
 ```
 
+In addition to the static `case` and `caseOn` functions on a type, instances of
+a type have `case` and `caseOf` methods, so for example
+
+```javascript
+Action.case({
+  Up: () => ({x: player.x, y: player.y - 1}),
+  Right: () => ({x: player.x + 1, y: player.y}),
+  Down: () => ({x: player.x, y: player.y + 1}),
+  Left: () => ({x: player.x - 1, y: player.y}),
+  _: () => player,
+}, action);
+```
+
+could equivalently be written as
+
+```javascript
+action.case({
+  Up: () => ({x: player.x, y: player.y - 1}),
+  Right: () => ({x: player.x + 1, y: player.y}),
+  Down: () => ({x: player.x, y: player.y + 1}),
+  Left: () => ({x: player.x - 1, y: player.y}),
+  _: () => player,
+});
+```
+
 ### Extracting fields from a union type
 
 If your type was defined using the record syntax you can access the fields

--- a/test/index.js
+++ b/test/index.js
@@ -196,6 +196,13 @@ describe('union type', function() {
       assert.deepEqual(update(Action.Move(5), Context), Context);
     });
   });
+  describe('case instance method', function() {
+    var Maybe = Type({Just: [Number], Nothing: []});
+    assert.equal(3, Maybe.Just(1).case({
+      Nothing: function () { return 'oops'; },
+      Just: function (n) { return n + 2; }
+    }));
+  });
   describe('recursive data types', function() {
     var List = Type({Nil: [], Cons: [T, List]});
     it('can create single element list', function() {

--- a/union-type.js
+++ b/union-type.js
@@ -115,10 +115,14 @@ function createIterator() {
 
 function Type(desc) {
   var key, res, obj = {};
-  obj.prototype = {};
-  obj.prototype[Symbol ? Symbol.iterator : '@@iterator'] = createIterator;
   obj.case = typeCase(obj);
   obj.caseOn = caseOn(obj);
+  
+  obj.prototype = {};
+  obj.prototype[Symbol ? Symbol.iterator : '@@iterator'] = createIterator;
+  obj.prototype.case = function (cases) { return obj.case(cases, this); }
+  obj.prototype.caseOn = function (cases) { return obj.caseOn(cases, this); }
+  
   for (key in desc) {
     res = constructor(obj, key, desc[key]);
   }


### PR DESCRIPTION
Add instance methods for `case` and `caseOn` so you can do e.g.

```javascript
const { Just, Nothing } = Type({
  Just: [T],
  Nothing: []
})

const m = Just(3)

m.case({
  Nothing: () => 0,
  Just: (n) => n + 2
})
```