### PR TITLE
With Type.check = false, avoid TypeError

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -180,6 +180,15 @@ describe('union type', function() {
         fn(Action.Rotate(30));
       }, /exhaustive/);
     });
+    it('does not throw with Type.check = false if no case handler found', function() {
+      Type.check = false;
+      Action.case({
+        Translate: function(x, y) {
+          return x + y;
+        }
+      }, Action.Rotate(90));
+      Type.check = true;
+    });
   });
   describe('caseOn', function() {
     var Modification = Type({Append: [Number], Remove: [Number], Slice: [Number, Number], Sort: []});

--- a/union-type.js
+++ b/union-type.js
@@ -96,10 +96,12 @@ function rawCase(type, cases, value, arg) {
       throw new Error('non-exhaustive patterns in a function');
     }
   }
-  var args = wildcard === true ? [arg]
-           : arg !== undefined ? valueToArray(value).concat([arg])
-           : valueToArray(value);
-  return handler.apply(undefined, args);
+  if (handler) {
+    var args = wildcard === true ? [arg]
+             : arg !== undefined ? valueToArray(value).concat([arg])
+             : valueToArray(value);
+    return handler.apply(undefined, args);
+  }
 }
 
 var typeCase = curryN(3, rawCase);

--- a/union-type.js
+++ b/union-type.js
@@ -96,7 +96,7 @@ function rawCase(type, cases, value, arg) {
       throw new Error('non-exhaustive patterns in a function');
     }
   }
-  if (handler) {
+  if (handler !== undefined) {
     var args = wildcard === true ? [arg]
              : arg !== undefined ? valueToArray(value).concat([arg])
              : valueToArray(value);


### PR DESCRIPTION
With `Type.check = false`, avoid TypeError: Cannot read property 'apply' of undefined.

After setting `Type.check = false`, we should be able to write a handler that handles some, but not all, cases, without needing a catchall `_`. This saves us from having to write boilerplate `_: function() { }` code in handlers.